### PR TITLE
Remove version references from install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-# Install the Remove Clock extension for GNOME Shell 48
+# Install the Remove Clock extension for GNOME Shell
 set -e
 
 UUID="removeclock@sudo-swe.com"
 DEST="$HOME/.local/share/gnome-shell/extensions/$UUID"
 
-echo "Installing Remove Clock extension for GNOME 48"
+echo "Installing Remove Clock extension"
 mkdir -p "$DEST"
 cp metadata.json extension.js "$DEST/"
 


### PR DESCRIPTION
## Summary
- remove GNOME 48 references from install.sh so the installer text is generic

## Testing
- `bash install.sh --help` *(fails: no such option)*

------
https://chatgpt.com/codex/tasks/task_b_6881586bc6808323b621838ebe54d2d5